### PR TITLE
Upgrade asgiref from 3.3.1 to 3.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ arrow==0.17.0
     # via
     #   -r requirements.in
     #   django-q
-asgiref==3.3.1
+asgiref>=3.4.0
     # via
     #   django
     #   djoser


### PR DESCRIPTION
Fixes the following issue.
```
Traceback (most recent call last):
  File "/usr/local/bin/uvicorn", line 5, in <module>
    from uvicorn.main import main
  File "/usr/local/lib/python3.7/site-packages/uvicorn/__init__.py", line 1, in <module>
    from uvicorn.config import Config
  File "/usr/local/lib/python3.7/site-packages/uvicorn/config.py", line 21, in <module>
    from asgiref.typing import ASGIApplication
ModuleNotFoundError: No module named 'asgiref.typing'
```

@hyakumori/maintainer
