### PR TITLE
Fix psycopg2-binary build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ COPY requirements.txt ${WORK_DIR}
 RUN apt update \
  && apt install -y \
     binutils \
+    gcc \
+    libpq-dev \
     libproj-dev \
     gdal-bin \
     wget \


### PR DESCRIPTION
Fixes #35.

Changes proposed in this pull request:
- Fix psycopg2-binary build by adding `libpq-dev` and `gcc`.

@hyakumori/maintainer
